### PR TITLE
Add a travis build to ensure 2.5.1 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
-before_install: gem install bundler -v 1.13.6
+  - 2.5.1
+matrix:
+  fast_finish: true
+  allow_failures:
+  - rvm: 2.5.1


### PR DESCRIPTION
# What is that about ❓ 

Creates a Travis build to ensure that this gem is compatible with *ruby 2.5.1* without messing with the current target version (2.3.1).